### PR TITLE
Support specifying service port with ENV

### DIFF
--- a/db.js
+++ b/db.js
@@ -8,7 +8,7 @@ const app = express()
 app.use(bodyParser.json()); // support json encoded bodies
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 
-const port = 8001
+const port = process.env.MICRO_DB_PORT || process.env.PORT || 9001;
 
 var dataStore = {}
 var oldestNotFinishedTask = 0
@@ -117,3 +117,5 @@ function startService() {
 		console.log(`Database is listening on ${port}`)
 	})
 }
+
+console.log("Running db on port: ", port);

--- a/keyvaluestore.js
+++ b/keyvaluestore.js
@@ -5,7 +5,7 @@ const app = express()
 app.use(bodyParser.json()); // support json encoded bodies
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 
-const port = 8000
+const port = process.env.MICRO_KEYVALUESTORE_PORT || process.env.PORT || 9000;
 
 var keyValueStore = {}
 
@@ -36,3 +36,5 @@ app.listen(port, (err) => {
 
     console.log(`server is listening on ${port}`)
 })
+
+console.log("Running keyvaluestore on port: ", port);

--- a/master.js
+++ b/master.js
@@ -11,7 +11,7 @@ app.use(bodyParser.json()); // support json encoded bodies
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 app.use(fileUpload())
 
-const port = 8003
+const port = process.env.MICRO_MASTER_PORT || process.env.PORT || 9003;
 
 var dbEndpoint
 var storageEndpoint
@@ -145,3 +145,5 @@ function startService() {
 		console.log(`Master is listening on ${port}`)
 	})
 }
+
+console.log("Running master on port: ", port);

--- a/storage.js
+++ b/storage.js
@@ -11,7 +11,7 @@ app.use(bodyParser.json()); // support json encoded bodies
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 app.use(fileUpload())
 
-const port = 8002
+const port = process.env.MICRO_STORAGE_PORT || process.env.PORT || 9002;
 
 if (process.argv.length < 3) {
     console.log("Usage: node storage.js <KEYVALUESTORE_ENDOPOINT>")
@@ -82,3 +82,5 @@ function startService() {
 		console.log(`Storage is listening on ${port}`)
 	})
 }
+
+console.log("Running storage on port: ", port);


### PR DESCRIPTION
Ports for services were hard-coded to:
```
8000 keyvaluestore
8001 db
8002 storage
8003 master
```
But these ports are often used by other services (e.g 8000 takes OSv http server, 8001 takes kubernetes GUI). Fixed this by changing default ports to 900x. Also supported setting port using environment variable. Variable name can be either `PORT` either `MICRO_<service_name>_PORT`. The first is useful when running in OSv and the latter when running locally.
