### PR TITLE
Allow workers to fetch keyvaluestore endpoint from ENV

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,0 +1,10 @@
+module.exports = {
+	getKeyvaluestoreEndpoint: function(){
+		if (process.argv.length == 3) {	    
+		    return 'http://' + process.argv[2];
+		} else if (process.env.MICRO_KEYVALUESTORE_ENDPOINT) {
+		    return 'http://' + process.env.MICRO_KEYVALUESTORE_ENDPOINT;
+		}
+		return false;
+	}
+};

--- a/db.js
+++ b/db.js
@@ -13,11 +13,11 @@ const port = process.env.MICRO_DB_PORT || process.env.PORT || 9001;
 var dataStore = {}
 var oldestNotFinishedTask = 0
 
-if (process.argv.length < 3) {
-    console.log("Usage: node db.js <KEYVALUESTORE_ENDOPOINT>")
-    process.exit()
-} else {
-    kvEndpoint = 'http://' + process.argv[2]
+kvEndpoint = require('./common').getKeyvaluestoreEndpoint();
+if (!kvEndpoint){
+	console.log("Usage: node db.js <KEYVALUESTORE_ENDOPOINT>")
+	console.log("Alternatively, specify MICRO_KEYVALUESTORE_ENDPOINT env variable.")
+	process.exit()
 }
 
 // Get DB IP and try to report it to the key-value registry
@@ -119,3 +119,4 @@ function startService() {
 }
 
 console.log("Running db on port: ", port);
+console.log("Using keyvaluestore endpoint: ", kvEndpoint);

--- a/keyvaluestore.js
+++ b/keyvaluestore.js
@@ -30,11 +30,11 @@ app.post('/:key/', function(req, res) {
 })
 
 app.listen(port, (err) => {  
-    if (err) {
-        return console.log('something bad happened', err)
-    }
+	if (err) {
+		return console.log('something bad happened', err)
+	}
 
-    console.log(`server is listening on ${port}`)
+	console.log(`server is listening on ${port}`)
 })
 
 console.log("Running keyvaluestore on port: ", port);

--- a/master.js
+++ b/master.js
@@ -3,7 +3,6 @@ var bodyParser = require('body-parser');
 var fileUpload = require('express-fileupload')
 var request = require('request')
 var ip = require('ip');
-
 var os = require('os');
 
 const app = express()  
@@ -16,11 +15,11 @@ const port = process.env.MICRO_MASTER_PORT || process.env.PORT || 9003;
 var dbEndpoint
 var storageEndpoint
 
-if (process.argv.length < 3) {
-    console.log("Usage: node db.js <KEYVALUESTORE_ENDOPOINT>")
-    process.exit()
-} else {
-    kvEndpoint = 'http://' + process.argv[2]
+kvEndpoint = require('./common').getKeyvaluestoreEndpoint();
+if (!kvEndpoint){
+	console.log("Usage: node master.js <KEYVALUESTORE_ENDOPOINT>")
+	console.log("Alternatively, specify MICRO_KEYVALUESTORE_ENDPOINT env variable.")
+	process.exit()
 }
 
 // Get Master IP and try to report it to the key-value registry
@@ -147,3 +146,4 @@ function startService() {
 }
 
 console.log("Running master on port: ", port);
+console.log("Using keyvaluestore endpoint: ", kvEndpoint);

--- a/storage.js
+++ b/storage.js
@@ -3,7 +3,6 @@ var bodyParser = require('body-parser');
 var fileUpload = require('express-fileupload')
 var request = require('request')
 var ip = require('ip');
-
 var os = require('os');
 
 const app = express()  
@@ -13,11 +12,11 @@ app.use(fileUpload())
 
 const port = process.env.MICRO_STORAGE_PORT || process.env.PORT || 9002;
 
-if (process.argv.length < 3) {
-    console.log("Usage: node storage.js <KEYVALUESTORE_ENDOPOINT>")
-    process.exit()
-} else {
-    kvEndpoint = 'http://' + process.argv[2]
+kvEndpoint = require('./common').getKeyvaluestoreEndpoint();
+if (!kvEndpoint){
+	console.log("Usage: node storage.js <KEYVALUESTORE_ENDOPOINT>")
+	console.log("Alternatively, specify MICRO_KEYVALUESTORE_ENDPOINT env variable.")
+	process.exit()
 }
 
 // Get DB IP and try to report it to the key-value registry
@@ -84,3 +83,4 @@ function startService() {
 }
 
 console.log("Running storage on port: ", port);
+console.log("Using keyvaluestore endpoint: ", kvEndpoint);

--- a/worker.js
+++ b/worker.js
@@ -13,11 +13,11 @@ app.use(fileUpload())
 var masterEndpoint
 var storageEndpoint
 
-if (process.argv.length < 3) {
-    console.log("Usage: node worker.js <KEYVALUESTORE_ENDOPOINT>")
-    process.exit()
-} else {
-    kvEndpoint = 'http://' + process.argv[2]
+kvEndpoint = require('./common').getKeyvaluestoreEndpoint();
+if (!kvEndpoint){
+	console.log("Usage: node worker.js <KEYVALUESTORE_ENDOPOINT>")
+	console.log("Alternatively, specify MICRO_KEYVALUESTORE_ENDPOINT env variable.")
+	process.exit()
 }
 
 getServiceEndpoints()
@@ -67,7 +67,7 @@ function doWork() {
 					})
 				})
 			} else {
-				setTimeout(doWork, 5000)	
+				setTimeout(doWork, 5000)
 			}
 		} else {
 			console.log("Nothing to do at the moment")
@@ -104,3 +104,5 @@ function getServiceEndpoints() {
 		setTimeout(getServiceEndpoints, 1000)
 	}
 }
+
+console.log("Using keyvaluestore endpoint: ", kvEndpoint);


### PR DESCRIPTION
Workers get endpoint as a script argument which does not fit into our `runtime: node` specification :) Fixed this by fetching endpoint from environment variable `MICRO_KEYVALUESTORE_ENDOPOINT` when script argument is not passed.