### PR TITLE
Implement UI

### DIFF
--- a/docker_deploy/Dockerfile-ui
+++ b/docker_deploy/Dockerfile-ui
@@ -1,0 +1,22 @@
+FROM node:4.8-wheezy
+
+# Install Node.js dependencies
+COPY package.json /
+RUN npm install
+
+# Copy project files to docker container
+COPY views/ /views/
+COPY ui.js /
+
+CMD node /ui.js
+
+#
+# NOTES
+#
+# Build this container with (from project root dir):
+# docker build -t mike/osv-microservice-demo-ui . -f docker_deploy/Dockerfile-ui
+#
+# Upload to kubernetes with:
+# docker save mike/osv-microservice-demo-ui | docker exec -i kube-node-1 docker load
+# docker save mike/osv-microservice-demo-ui | docker exec -i kube-node-2 docker load
+#

--- a/docker_deploy/README.md
+++ b/docker_deploy/README.md
@@ -1,0 +1,33 @@
+# Deploy on Kubernetes using Docker containers
+
+In our environment it was `PROJECT_DIR=$HOME/git-repos/osv-microservice-demo`.
+
+## UI
+
+Build container using the provided Dockerfile-ui:
+```bash
+$ cd $PROJECT_DIR
+$ npm install
+$ docker build -t mike/osv-microservice-demo-ui . -f docker_deploy/Dockerfile-ui
+```
+
+Optionally, you can run container locally to see if everything is allright:
+```bash
+$ docker run -t mike/osv-microservice-demo-ui
+Master endpoint: http://micro-master.default.svc.cluster.local
+Ui is listening on 80
+```
+
+Inject container to all DIND nodes since we don't know where Deployment will be scheduled:
+```bash
+$ docker save mike/osv-microservice-demo-ui | docker exec -i kube-node-1 docker load
+$ docker save mike/osv-microservice-demo-ui | docker exec -i kube-node-2 docker load
+```
+
+Deploy on Kubernetes:
+```bash
+$ kubectl create -f docker_deploy/micro-ui.yaml
+```
+
+At this point Deployment should exist on Kubernetes with a single Pod. Visiting the Pod's IP should
+show you the UI on port 80 by default.

--- a/docker_deploy/micro-ui.yaml
+++ b/docker_deploy/micro-ui.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: micro-ui
+  namespace: default
+spec:
+  replicas: 1
+  template:  
+    metadata:
+      labels:
+          case: micro-ui      
+    spec:
+      containers:
+      - name: web
+        image: mike/osv-microservice-demo-ui
+        imagePullPolicy: Never
+        env:
+        - name: MICRO_MASTER_ENDPOINT
+          value: http://micro-master.default.svc.cluster.local 
+        ports:
+        - name: web
+          containerPort: 80

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "express": "^4.14.1",
     "express-fileupload": "0.0.6",
     "ip": "^1.1.5",
+    "jade": "^1.11.0",
     "jimp": "^0.2.27",
     "request": "^2.79.0"
   },

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,67 @@
+const express = require('express')  
+var bodyParser = require('body-parser');
+var request = require('request').defaults({ encoding: null });
+var jade = require('jade');
+var fs = require('fs');
+var fileUpload = require('express-fileupload')
+
+const app = express()  
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(fileUpload())
+app.set('view engine', 'jade')
+
+
+const port = process.env.MICRO_UI_PORT || process.env.PORT || 80;
+const masterEndpoint = process.env.MICRO_MASTER_ENDPOINT || "http://micro-master.default.svc.cluster.local";
+const uploadImageUrl = masterEndpoint + '/task'
+
+function startService() {
+	app.listen(port, (err) => {
+		if (err) {
+			return console.log('something bad happened', err)
+		}
+		console.log(`UI is listening on ${port}`)
+	})
+}
+
+app.get('/', (req, res) => {
+	var taskId = req.query.taskId;
+	taskId = taskId ? taskId : "0";
+	downloadImageUrl = `${masterEndpoint}/task/${taskId}/download`;
+
+	request.get({url: downloadImageUrl, timeout: 3000}, function (error, response, body) {
+	    if (!error && response.statusCode == 200) {
+	        data = "data:" + response.headers["content-type"] + ";base64," + new Buffer(body).toString('base64'); 
+	        res.render('index', { service: downloadImageUrl, imgData: data});
+	    }else{
+	    	res.render('index', { service: downloadImageUrl, imgData: "", message: "NO RESULT FOUND!"});
+	    }
+	});
+})
+
+app.get('/upload', (req, res) => {	
+	res.render('upload', { service: uploadImageUrl});
+})
+
+app.post('/upload', (req, res) => {
+	var postParams = {
+		uri: uploadImageUrl,
+		formData: {
+			image: req.files.image.data
+		},
+		timeout: 3000
+	};
+
+	request.post(postParams, (storageError, storageResponse, storageBody) => {
+		if (!storageError && storageResponse.statusCode == 200) {
+			res.render('upload', { service: uploadImageUrl});
+		} else {
+			res.status(500).send("Error uploading image: " + storageError);
+		}
+	});	
+})
+
+startService();
+
+console.log("Master endpoint:", masterEndpoint);

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,0 +1,16 @@
+html
+  head
+    title MIKELANGELO Node Microservice Application
+  body
+    h1 MIKELANGELO Node Microservice Application    
+
+    p Result of image processing:
+    img(alt="Processed image" src="#{imgData}")
+
+    p #{message}
+
+    p 
+      | Image was downloaded from address:
+      b  #{service}
+
+    a(href="/upload") Upload .png image for processing

--- a/views/upload.jade
+++ b/views/upload.jade
@@ -1,0 +1,15 @@
+html
+  head
+    title MIKELANGELO Node Microservice Application
+  body
+    h1 MIKELANGELO Node Microservice Application
+    p Upload file for processing:
+    form(method="POST", action="/upload", encType="multipart/form-data")
+      input(type="file", name="image")
+      input(type="submit")
+    
+    p 
+      | Image will be uploaded to address:
+      b  #{service}
+
+    a(href="/") View result


### PR DESCRIPTION
This commit introduces ui.js that serves two web pages:

- `/` where one can view processing result (taskId=0 by default,
      but can be customized with querystring `?taskId=123`)
- `/upload` where one can upload PNG image

Both upload and download interact with master node only. Master endpoint can be set as environment variable.

Well at the moment the UI looks awful, so we might consider adding some CSS and images in near future!

The homepage `/`:
![capture](https://cloud.githubusercontent.com/assets/8102426/24999306/4e295d44-203d-11e7-832a-9a86362fa058.PNG)

The upload page `/upload`:
![capture](https://cloud.githubusercontent.com/assets/8102426/24999327/61a7e386-203d-11e7-99a5-35d22407bc58.PNG)

