### PR TITLE
Allow keyvaluestore.js to set endpoints from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once the services are registered, the application can be used. The collaboration
 
 ## Using the Application
 
-Before you can use the application, ensure you have Node.js installed (version 4.2.6 was used for this tutorial). Navigate to the root directory of this project and install required packages
+Before you can use the application, ensure you have Node.js installed (version 4.4.5 was used for this tutorial). Navigate to the root directory of this project and install required packages
 
 ```
 $ npm install
@@ -127,7 +127,7 @@ name: node-micro
 title: Node Microservices
 author: lemmy
 require:
-- eu.mikelangelo-project.app.node-4.2.6
+- eu.mikelangelo-project.app.node-4.4.5
 ```
 
 `name`, `title` and `author` are used by Capstan mainly for displaying this information at various places. The `require` lists all packages that need to be collected while composing target unikernel (target VM comprised of bootloader, OSv kerenel and your application). To get a list of packages available for download, use `capstan package search` command. When looking for a specific package, add the name, for example

--- a/keyvaluestore.js
+++ b/keyvaluestore.js
@@ -8,8 +8,11 @@ app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 const port = process.env.MICRO_KEYVALUESTORE_PORT || process.env.PORT || 9000;
 
 var keyValueStore = {}
+keyValueStore['masterendpoint'] = process.env.MICRO_MASTER_ENDPOINT;
+keyValueStore['dbendpoint'] = process.env.MICRO_DB_ENDPOINT;
+keyValueStore['storageendpoint'] = process.env.MICRO_STORAGE_ENDPOINT;
 
-app.get('/:key/', (req, res) => {  
+app.get('/:key/', (req, res) => {
 	var key = req.params.key
 
 	if (key in keyValueStore) {
@@ -25,7 +28,11 @@ app.post('/:key/', function(req, res) {
 
 	console.log(key + "=" + value)
 
-	keyValueStore[key] = value
+	if (!keyValueStore[key]) {
+		keyValueStore[key] = value;
+	} else {
+		console.log('Prevented updating keyvaluestore, key = ' + key, ', value = ' + value);
+	}
 	res.send('')
 })
 

--- a/meta/package.yaml
+++ b/meta/package.yaml
@@ -2,4 +2,4 @@ name: node-micro
 title: Node Microservices
 author: lemmy
 require:
-- eu.mikelangelo-project.app.node-4.2.6
+- eu.mikelangelo-project.app.node-4.4.5

--- a/meta/run.yaml
+++ b/meta/run.yaml
@@ -1,0 +1,33 @@
+#
+# In this file we specify how each microservice should boot.
+#
+
+runtime: node
+
+config_set: 
+   virtlet_keyvaluestore:
+      main: keyvaluestore.js
+      env:
+         PORT: 9000
+         MICRO_MASTER_ENDPOINT: micro-master.default.svc.cluster.local
+         MICRO_DB_ENDPOINT: micro-db.default.svc.cluster.local
+         MICRO_STORAGE_ENDPOINT: micro-storage.default.svc.cluster.local
+   virtlet_db:
+      main: db.js
+      env:
+         PORT: 9001
+         MICRO_KEYVALUESTORE_ENDPOINT: micro-keyvaluestore.default.svc.cluster.local
+   virtlet_storage:
+      main: storage.js
+      env:
+         PORT: 9002
+         MICRO_KEYVALUESTORE_ENDPOINT: micro-keyvaluestore.default.svc.cluster.local
+   virtlet_master:
+      main: master.js
+      env:
+         PORT: 9003
+         MICRO_KEYVALUESTORE_ENDPOINT: micro-keyvaluestore.default.svc.cluster.local
+   virtlet_worker:
+      main: worker.js
+      env:
+         MICRO_KEYVALUESTORE_ENDPOINT: micro-keyvaluestore.default.svc.cluster.local


### PR DESCRIPTION
When running on Kubernetes, service endpoints will be known upfront since we will be calling them by name. So we support setting them by the means of environment variables in this commit. We also provide a meta/run.yaml.