### PR TITLE
Provide meta/run.yaml to simplify running

### DIFF
--- a/meta/run.yaml
+++ b/meta/run.yaml
@@ -1,0 +1,30 @@
+#
+# In this file we specify how each microservice should boot.
+#
+
+runtime: node
+
+config_set: 
+   keyvaluestore:
+      main: /keyvaluestore.js
+      env:
+         PORT: 9000
+   db:
+      main: /db.js
+      env:
+         PORT: 9001         
+         MICRO_KEYVALUESTORE_ENDPOINT: $MICRO_KEYVALUESTORE_ENDPOINT
+   storage:
+      main: /storage.js
+      env:
+         PORT: 9002
+         MICRO_KEYVALUESTORE_ENDPOINT: $MICRO_KEYVALUESTORE_ENDPOINT
+   master:
+      main: /master.js
+      env:
+         PORT: 9003
+         MICRO_KEYVALUESTORE_ENDPOINT: $MICRO_KEYVALUESTORE_ENDPOINT
+   worker:
+      main: /worker.js
+      env:
+         MICRO_KEYVALUESTORE_ENDPOINT: $MICRO_KEYVALUESTORE_ENDPOINT


### PR DESCRIPTION
While trying to provide `meta/run.yaml` to run this application I've encountered an annoying problem: keyvaluestore endpoint is not known on build time. So I would like to discuss how should we proceed. What one can do at the moment is:
```bash
# generate scripts in /run/...
$ capstan package compose micro

# set boot command to `runscript /run/master`
$ capstan run micro --boot master

# equivalent:
$ capstan run micro --execute "runscript /run/master"

# if I want to set environment variable I can do it like this
$ capstan run micro --execute "--env=MICRO_KEYVALUESTORE_ENDPOINT=172.16.1.205:9000 runscript /run/master"
```

What I'm thinking is that we should upgrade Capstan to be able to generate command with env variable:
```bash
# does not work yet, the --env flag needs to be implemented:
$ capstan run micro --boot master --env=MICRO_KEYVALUESTORE_ENDPOINT=172.16.1.205:9000

```

What do you think?