### PR TITLE
Add mpm-pkg to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+mpm-pkg


### PR DESCRIPTION
If user played with `capstan package collect` then the `git diff` would go crazy. Not anymore, the folder is now ignored.