### PR TITLE
Add .capstanignore to reduce unikernel size

### DIFF
--- a/.capstanignore
+++ b/.capstanignore
@@ -1,0 +1,27 @@
+#
+# Here we specify what files/folders should NOT be uploaded to the unikernel.
+#
+
+# Whole folders
+/.idea
+/bin
+/doc
+/docker_deploy
+
+# Ignore everything inside /data/storage/, /data/worker/, ... but keep the (empty) directories.
+/data/*/*
+
+# Specific files
+/package.json
+/*.png
+
+# Ignore any clutter files that usually appear inside node_modules
+/**/*.md
+/**/AUTHORS
+/**/LICENSE
+/**/.editorconfig
+/**/.gitattributes
+/**/.npmignore
+/**/.tern-project
+/**/.travis.yml
+/**/.keep


### PR DESCRIPTION
A list of files/folders that should not get uploaded to the unikernel is provided to reduce OSv unikernel size even more. Also, if user was following README tutorial, she probably already has some .png images in `/data/storage/` and `/data/worker/` folder and they should not be uploaded to the unikernel.

Before .capstanignore: 3781 files, 38 MB size on disk
After  .capstanignore: 3182 filse, 35 MB size on disk